### PR TITLE
Force email to lowercase

### DIFF
--- a/Classes/Controller/PasswordManagementController.php
+++ b/Classes/Controller/PasswordManagementController.php
@@ -95,6 +95,14 @@ class PasswordManagementController extends ActionController
      */
     protected $authenticationManager;
 
+    public function initializeRequestResetAction()
+    {
+        if ($this->request->hasArgument('email')) {
+            $email = $this->request->getArgument('email');
+            $this->request->setArgument('email', mb_strtolower($email));
+        }
+    }
+
     /**
      * @param string $email
      * @param string $redirectNodeIdentifier Identifier of node for redirect


### PR DESCRIPTION
Force email to lowercase to prevent issues having seperate accounts for the same email address in different spelling, i.e. foobar@example.com == FooBar@example.com