### PR TITLE
#21 Handle empty email address

### DIFF
--- a/Classes/Controller/PasswordManagementController.php
+++ b/Classes/Controller/PasswordManagementController.php
@@ -115,6 +115,15 @@ class PasswordManagementController extends ActionController
      */
     public function requestResetAction(string $email, string $redirectNodeIdentifier, string $resetNodeIdentifier): void
     {
+
+        $redirectNode = $this->getTargetNode($redirectNodeIdentifier);
+        $resetNode = $this->getTargetNode($resetNodeIdentifier);
+
+        if ($email === "") {
+            $this->request->setArgument('resetSuccess', false);
+            $this->redirectToNode($redirectNode);
+        }
+
         $account = null;
         foreach($this->settings['authenticationProviders'] as $authenticationProviderName) {
             $account = $this->accountRepository->findByAccountIdentifierAndAuthenticationProviderName($email, $authenticationProviderName);
@@ -122,9 +131,6 @@ class PasswordManagementController extends ActionController
                 break;
             }
         }
-
-        $redirectNode = $this->getTargetNode($redirectNodeIdentifier);
-        $resetNode = $this->getTargetNode($resetNodeIdentifier);
 
         if ($account === null) {
             $this->emitAccountForRequestedResetIsNotFound($email, $redirectNode);

--- a/Resources/Private/Fusion/Components/Atoms/RequestForm.fusion
+++ b/Resources/Private/Fusion/Components/Atoms/RequestForm.fusion
@@ -11,7 +11,7 @@ prototype(Networkteam.Neos.PasswordReset:Components.Atoms.RequestForm) < prototy
         <div class="password-reset">
             <form action={props.formAction} method="post">
                 <label for="password-reset-email-address">E-Mailaddresse:</label>
-                <input type="email" name="email" />
+                <input type="email" name="email" required />
                 <input type="hidden" name="redirectNodeIdentifier" value={node.identifier} />
                 <input type="hidden" name="resetNodeIdentifier" value={node.identifier} />
                 <button class="btn btn-primary" type="submit">Password reset</button>


### PR DESCRIPTION
This PR adds the `required` attribute to the email input field for client side validation and further more checks in the action if an empty email was provided.


Refs: #21 